### PR TITLE
Add support for bool ops (and / or) in tests and assignments

### DIFF
--- a/pygetsource/utils.py
+++ b/pygetsource/utils.py
@@ -110,22 +110,3 @@ def graph_sort(root):
     # TODO handle disjoint components
     dfs(root)
     return order[::-1]
-
-
-def get_origin(trees: ast.AST):
-    offset = None
-    origin = None
-    if isinstance(trees, ast.AST):
-        trees = [trees]
-    for tree in trees:
-        for node in ast.walk(tree):
-            try:
-                if offset is None:
-                    offset = node._origin_offset
-                    origin = node._origin_node
-                elif node._origin_offset < offset:
-                    offset = node._origin_offset
-                    origin = node._origin_node
-            except AttributeError:
-                pass
-        return origin, offset

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -830,3 +830,143 @@ def test_while_true_if_if_continue():
             if y:
                 continue
         return line
+
+
+@make_test_idem
+def test_while_test_if_else_break():
+    while test:
+        if a:
+            x = 2
+        else:
+            x = 3
+            break
+    return "a"
+
+
+@make_test_idem
+def test_while_if_if_elif_else():
+    while test:
+        if a:
+            if i == 0:
+                x = 1
+            elif i == 1:
+                x = 0
+                break
+            else:
+                i = 3
+                continue
+
+    x = 2
+    y = 3
+    return "a"
+
+
+@make_test_idem
+def test_while_while_if():
+    while z:
+        while test:
+            if i == 0:
+                x = 1
+            elif i == 1:
+                x = 0
+                continue
+            else:
+                i = 3
+                continue
+
+    u = 3
+    return u
+
+
+@make_test_idem
+def test_if_and_else():
+    if x and y:
+        x = 3
+    else:
+        y = 3
+
+    a = 3
+    return a
+
+
+@make_test_idem
+def test_if_and():
+    if x and y:
+        return 1
+
+
+@make_test_idem
+def test_if_or_else():
+    if x or y:
+        x = 3
+    else:
+        y = 3
+
+    a = 3
+    return a
+
+
+@make_test_idem
+def test_if_or():
+    if x or y:
+        return 1
+
+
+@make_test_idem
+def test_if_mix_bool_else():
+    if (x or y or z) and (a or b):
+        x = 3
+    else:
+        y = 3
+
+
+@make_test_idem
+def test_if_mix_bool_2_else():
+    if (x and y and z) or (a and b):
+        x = 3
+    else:
+        y = 3
+
+
+@make_test_idem
+def test_while_bool():
+    while a and b:
+        x = 2
+
+    u = 3
+    return "u"
+
+
+@make_test_idem
+def test_while_while_bool():
+    while a and b:
+        while test:
+            x = 2
+
+    u = 3
+    return "u"
+
+
+@make_test_idem
+def test_while_while_bool_mix():
+    while (x and y and z) or (a and b):
+        while test:
+            x = 2
+
+    u = 3
+    return "u"
+
+
+@make_test_idem
+def test_bool_and_of_or_assign():
+    z = (x and y and z) or (a and b) or (c and d)
+
+
+@make_test_idem
+def test_bool_or_of_and_assign():
+    z = (x or y or z) and (a or b) and (c or d)
+
+
+@make_test_idem
+def test_bool_target_in_comprehension():
+    return [(x or y or z) and (a or b) and (c or d) for i in range(10)]

--- a/todo.md
+++ b/todo.md
@@ -21,17 +21,17 @@ Current supported opcodes and syntaxes
 - [x] BINARY_XOR
 - [x] BUILD_CONST_KEY_MAP
 - [x] BUILD_LIST
-- [ ] BUILD_LIST_UNPACK
+- [x] BUILD_LIST_UNPACK
 - [x] BUILD_MAP
-- [ ] BUILD_MAP_UNPACK
-- [ ] BUILD_MAP_UNPACK_WITH_CALL
+- [x] BUILD_MAP_UNPACK
+- [x] BUILD_MAP_UNPACK_WITH_CALL
 - [x] BUILD_SET
-- [ ] BUILD_SET_UNPACK
+- [x] BUILD_SET_UNPACK
 - [x] BUILD_SLICE
 - [x] BUILD_STRING
 - [x] BUILD_TUPLE
-- [ ] BUILD_TUPLE_UNPACK
-- [ ] BUILD_TUPLE_UNPACK_WITH_CALL
+- [x] BUILD_TUPLE_UNPACK
+- [x] BUILD_TUPLE_UNPACK_WITH_CALL
 - [ ] CALL_FINALLY
 - [x] CALL_FUNCTION
 - [x] CALL_FUNCTION_EX
@@ -87,9 +87,9 @@ Current supported opcodes and syntaxes
 - [x] IS_OP
 - [x] JUMP_ABSOLUTE
 - [x] JUMP_FORWARD
-- [ ] JUMP_IF_FALSE_OR_POP
+- [x] JUMP_IF_FALSE_OR_POP
+- [x] JUMP_IF_TRUE_OR_POP
 - [ ] JUMP_IF_NOT_EXC_MATCH
-- [ ] JUMP_IF_TRUE_OR_POP
 - [x] LIST_APPEND
 - [x] LIST_EXTEND
 - [x] LIST_TO_TUPLE
@@ -176,7 +176,7 @@ Current supported opcodes and syntaxes
 - [x] Nonlocal: see `pygetsource.getfactory`
 - [x] Expr
 - [x] Pass | Break | Continue
-- [ ] BoolOp
+- [x] BoolOp
 - [ ] NamedExpr
 - [x] BinOp
 - [x] UnaryOp


### PR DESCRIPTION
Added support for Boolean operations (`and` & `or`) in assignments and tests.
These operations are much trickier than one might think, since these operators are [lazily evaluated](https://en.wikipedia.org/wiki/Short-circuit_evaluation).