### PR TITLE
Coroutines & inspect strategy

### DIFF
--- a/pygetsource/ast_utils.py
+++ b/pygetsource/ast_utils.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 
 
 class Unpacking(ast.AST):
@@ -237,3 +238,18 @@ def make_bool_op(op, values):
         else:
             new_values.append(v)
     return ast.BoolOp(op=op, values=new_values)
+
+
+def reconstruct_arguments_str(code):
+    arg_details = inspect.getargs(code)
+    sig = []
+    if len(arg_details.args):
+        sig.append(", ".join(arg_details.args))
+    keyword_only_args = getattr(arg_details, "kwonlyargs", None)
+    if keyword_only_args:
+        sig.append("*, " + ", ".join(keyword_only_args))
+    if arg_details.varargs:
+        sig.append("*" + arg_details.varargs)
+    if arg_details.varkw:
+        sig.append("**" + arg_details.varkw)
+    return ", ".join(sig)

--- a/pygetsource/utils.py
+++ b/pygetsource/utils.py
@@ -120,6 +120,7 @@ hasjabs = [
     "JUMP_IF_TRUE_OR_POP",
     "JUMP_IF_NOT_EXC_MATCH",
     "SETUP_FINALLY",
+    "SEND",
 ]
 
 no_ops = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,17 @@
 name = "pygetsource"
 description = "A Python 3 decompiler"
 authors = [
-    { name = "Perceval Wajsburt", email = "perceval.wajsburt@gmail.com" }
+    { name = "Perceval Wajsbürt", email = "perceval.wajsburt@gmail.com" }
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-urls.homepage = "https://github.com/perceval/pygetsource/"
-urls.repository = "https://github.com/perceval/pygetsource/"
+urls.homepage = "https://github.com/percevalw/pygetsource/"
+urls.repository = "https://github.com/percevalw/pygetsource/"
 dynamic = ["version"]
 requires-python = ">=3.7,<4.0"
 dependencies = [
     "astunparse",
+    "typing_extensions",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/test_py37.py
+++ b/tests/test_py37.py
@@ -970,3 +970,23 @@ def test_bool_or_of_and_assign():
 @make_test_idem
 def test_bool_target_in_comprehension():
     return [(x or y or z) and (a or b) and (c or d) for i in range(10)]
+
+
+@make_test_idem
+async def test_await_simple():
+    await z
+
+
+@make_test_idem
+async def test_await_store():
+    x = await z
+
+
+@make_test_idem
+def test_yield_from_simple():
+    yield from z
+
+
+@make_test_idem
+def test_yield_from_store():
+    x = yield from z

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -6,6 +6,8 @@ other Function attributes.
 """
 from typing import Callable
 
+import pytest
+
 from pygetsource.factory import getfactory
 
 
@@ -13,7 +15,7 @@ def test_simple():
     def func(a, b):
         return a + b
 
-    source_code = getfactory(func.__code__)
+    source_code = getfactory(func.__code__, strategy="decompile")
     res = {}
     exec(source_code, res, res)
     recompiled: Callable = res["_fn_"]
@@ -24,7 +26,7 @@ def test_kw_only_args():
     def func(a, *, b=1):
         return a + b
 
-    source_code = getfactory(func.__code__)
+    source_code = getfactory(func.__code__, strategy="decompile")
     print("source_code", source_code)
     res = {}
     exec(source_code, res, res)
@@ -36,8 +38,36 @@ def test_kwargs():
     def func(a, **d):
         return a + sum(d.values())
 
-    source_code = getfactory(func.__code__)
+    source_code = getfactory(func.__code__, strategy="decompile")
     res = {}
     exec(source_code, res, res)
     recompiled: Callable = res["_fn_"]
     assert recompiled(a=1, b=2, c=2) == 5
+
+
+def test_simple_inspect():
+    def func(a, b):
+        return a + b
+
+    source_code = getfactory(func.__code__, strategy="inspect")
+    res = {}
+    exec(source_code, res, res)
+    recompiled: Callable = res["_fn_"]
+    assert recompiled(1, 2) == 3
+
+
+def test_lambda_auto():
+    func = lambda a, b: a + b  # noqa: E731
+
+    source_code = getfactory(func.__code__, strategy="auto")
+    res = {}
+    exec(source_code, res, res)
+    recompiled: Callable = res["_fn_"]
+    assert recompiled(1, 2) == 3
+
+
+def test_lambda_inspect_fail():
+    func = lambda a, b: a + b  # noqa: E731
+
+    with pytest.raises(ValueError):
+        getfactory(func.__code__, strategy="inspect")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,7 +44,7 @@ def prune_and_compare(code1: CodeType, code2: CodeType):
 
 def make_test_idem(func):
     def test():
-        source_code = getfactory(func.__code__)
+        source_code = getfactory(func.__code__, strategy="decompile")
         res = {}
         exec(source_code, res, res)
         recompiled: Callable = res["_fn_"]

--- a/todo.md
+++ b/todo.md
@@ -64,10 +64,10 @@ Current supported opcodes and syntaxes
 - [x] GEN_START
 - [ ] GET_AITER
 - [ ] GET_ANEXT
-- [ ] GET_AWAITABLE
+- [x] GET_AWAITABLE
 - [x] GET_ITER
 - [ ] GET_LEN
-- [ ] GET_YIELD_FROM_ITER
+- [x] GET_YIELD_FROM_ITER
 - [ ] IMPORT_FROM
 - [ ] IMPORT_NAME
 - [ ] IMPORT_STAR
@@ -146,7 +146,7 @@ Current supported opcodes and syntaxes
 - [ ] WITH_CLEANUP_FINISH
 - [ ] WITH_CLEANUP_START
 - [ ] WITH_EXCEPT_START
-- [ ] YIELD_FROM
+- [x] YIELD_FROM
 - [ ] YIELD_VALUE
 - [x] CACHE
 - [x] PUSH_NULL
@@ -162,7 +162,7 @@ Current supported opcodes and syntaxes
 - [x] POP_JUMP_FORWARD_IF_TRUE
 - [x] COPY
 - [x] BINARY_OP
-- [ ] SEND
+- [x] SEND
 - [ ] POP_JUMP_FORWARD_IF_NOT_NONE
 - [ ] POP_JUMP_FORWARD_IF_NONE
 - [ ] JUMP_BACKWARD_NO_INTERRUPT
@@ -217,9 +217,9 @@ Current supported opcodes and syntaxes
 - [x] SetComp
 - [x] DictComp
 - [x] GeneratorExp
-- [ ] Await
+- [x] Await
 - [ ] Yield
-- [ ] YieldFrom
+- [x] YieldFrom
 - [x] Compare
 - [x] Call
 - [x] FormattedValue


### PR DESCRIPTION
- Support `async` / `await` / `yield from` syntaxes
- Added a new `inspect` based strategy (default is `auto`, and decompiled is `decompile`) to `getfactory`