### PR TITLE
Fix factory with docstrings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Upload Python Package
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [ published ]
 
 permissions:
   contents: read
@@ -24,16 +24,19 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,31 +8,32 @@ on:
 
 jobs:
   Linting:
-    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - name: Set PY variable
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Install pre-commit
-        run: |
-          pip install pre-commit
-          pre-commit install
-      - name: Run pre-commit
-        run: SKIP=no-commit-to-branch pre-commit run --all-files
+          # requites to grab the history of the PR
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        with:
+          cache: 'pip'
+
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --color=always --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
 
   Pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # for python 3.7
     strategy:
       fail-fast: true
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/pygetsource/factory.py
+++ b/pygetsource/factory.py
@@ -14,7 +14,15 @@ def inspect_function_code(code: CodeType):
     tree = ast.parse(textwrap.dedent(source_code))
     body = tree.body[0]
     lines = source_code.splitlines()
-    function_body = textwrap.dedent("\n".join(lines[body.body[0].lineno - 1 :]))
+    body_lines = lines[body.body[0].lineno - 1 :]
+    if (
+        "\n".join(body_lines).count('"""') % 2 == 1 and body_lines[0].strip() == '"""'
+    ) or (
+        "\n".join(body_lines).count("'''") % 2 == 1 and body_lines[0].strip() == "'''"
+    ):
+        body_lines = body_lines[1:]
+
+    function_body = textwrap.dedent("\n".join(body_lines))
     def_str = "async def" if isinstance(body, ast.AsyncFunctionDef) else "def"
     function_name = body.name
 

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -71,3 +71,17 @@ def test_lambda_inspect_fail():
 
     with pytest.raises(ValueError):
         getfactory(func.__code__, strategy="inspect")
+
+
+def test_inspect_docstring():
+    def func(a, b):
+        """
+        My docstring
+        """
+        return a + b
+
+    source_code = getfactory(func.__code__, strategy="inspect")
+    res = {}
+    exec(source_code, res, res)
+    recompiled: Callable = res["_fn_"]
+    assert recompiled(1, 2) == 3


### PR DESCRIPTION
Support docstring when using `getfactory` with functions with a docstring in python 3.7, e.g.

```
def func(a, b):
    """
    My docstring
    """
    return a + b

getfactory(func.__code__, strategy="inspect")
```

caused issues before, returning:

```
def func(a, b):
  """
  return a + b

_fn_ = func
```

Now, we just drop the docstring.