### PR TITLE
feat: improved support for py312

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,23 @@ jobs:
           pip install -e '.[dev]'
 
       - name: Test with Pytest on Python ${{ matrix.python-version }}
-        run: python -m pytest --cov pygetsource --cov-report xml
+        run: coverage run -m pytest --cov-report xml
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python-version }}
+          path: .coverage*
+          if-no-files-found: ignore
+          include-hidden-files: true
+
+  coverage:
+    name: Coverage
+    needs: Pytest
+    uses: aphp/foldedtensor/.github/workflows/coverage.yml@main
+    with:
+      base-branch: main
+      coverage-data-pattern: coverage-data-*
+      coverage-report: coverage.txt
+      coverage-badge: coverage.svg
+      coverage-branch: coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         additional_dependencies: [black==20.8b1]
         exclude: notebooks/
   - repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
+    rev: 1.7.0
     hooks:
       - id: interrogate
         args: ["--config=pyproject.toml"]

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+- Added partial Python 3.12 decompilation support (new opcode/jump encodings such as `RETURN_CONST`, `COMPARE_OP`, `POP_JUMP_*`, `FOR_ITER`, and `END_FOR` handling).
+- Improved reconstruction for conditional expressions to account for specific control-flow artifacts in generated source.
+- Added recovery of inline Python 3.12 comprehensions (filters and nested) back to `list`/`set`/`dict` comprehensions.
+
+## v0.4.0
+
+- Stable baseline focused on pre-3.12 bytecode patterns.
+- Python 3.12 support was limited/incomplete.

--- a/pygetsource/utils.py
+++ b/pygetsource/utils.py
@@ -125,6 +125,10 @@ hasjabs = [
 
 no_ops = [
     "NOP",
+    "END_FOR",
+    "END_SEND",
+    "CLEANUP_THROW",
+    "JUMP_BACKWARD_NO_INTERRUPT",
     "POP_BLOCK",
     "SETUP_LOOP",
     "RESUME",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,17 +58,30 @@ testpaths = [
 ]
 
 [tool.coverage.report]
-exclude_also = [
+precision = 2
+include = ["pygetsource/*"]
+omit = [
+    "tests/*",
+]
+exclude_lines = [
     "def __repr__",
-    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "@overload",
+    "pragma: no cover",
     "raise .*Error",
     "raise .*Exception",
+    "warn\\(",
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
     "if DEBUG:",
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
-    ]
+]
+
+[tool.coverage.run]
+include = ["pygetsource/*"]
+concurrency = ["multiprocessing", "thread"]
+parallel = true
 
 # ----- Documentation -----
 [tool.interrogate]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,50 @@
+import dis
+import sys
 from types import CodeType
 from typing import Callable
 
+from opcode import hasjabs
+
 from pygetsource import Node
 from pygetsource.factory import getfactory
+
+
+def nicer_bytecode(x: bytes):
+    s = ""
+    for code, arg in zip(x[::2], x[1::2]):
+        s += f"{dis.opname[code]} {arg}\n"
+    return s
+
+
+def remove_nop_codes(bytecode):
+    NOP = dis.opmap["NOP"]
+    shifts = [0] * (len(bytecode) // 2)
+    res = []
+    for i, (op, arg) in enumerate(zip(bytecode[::2], bytecode[1::2])):
+        if sys.version_info < (3, 10) and dis.opname[op] in hasjabs:
+            arg //= 2
+
+        if op == NOP:
+            for j in range(i + 1, len(shifts)):
+                shifts[j] = (shifts[j - 1] - 1) if j > 0 else 0
+        else:
+            for j in range(i + 1, len(shifts)):
+                shifts[j] = shifts[j - 1] if j > 0 else 0
+
+    for i, (op, arg) in enumerate(zip(bytecode[::2], bytecode[1::2])):
+        opname = dis.opname[op]
+        if sys.version_info < (3, 10) and opname in hasjabs:
+            arg //= 2
+        if op != NOP:
+            if opname in ("JUMP_FORWARD", "FOR_ITER", "SETUP_FINALLY"):
+                arg += shifts[i + arg] - shifts[i]
+            elif "JUMP" in opname:
+                arg += shifts[arg]
+
+            if sys.version_info < (3, 10) and opname in hasjabs:
+                arg *= 2
+            res.extend([op.to_bytes(1, "big"), arg.to_bytes(1, "big")])
+    return b"".join(res)
 
 
 def prune_and_compare(code1: CodeType, code2: CodeType):
@@ -56,9 +98,15 @@ def make_test_idem(func):
         )
         assert len(tgt_codes) == len(gen_codes)
         for tgt_code, gen_code in zip(gen_codes, tgt_codes):
-            assert prune_and_compare(gen_code, tgt_code)
-            # nice_gen = nicer_bytecode(remove_nop_codes(gen_code.co_code))
-            # nice_tgt = nicer_bytecode(remove_nop_codes(tgt_code.co_code))
+            nice_gen = nicer_bytecode(
+                gen_code.co_code
+            )  # remove_nop_codes(gen_code.co_code))
+            nice_tgt = nicer_bytecode(
+                tgt_code.co_code
+            )  # remove_nop_codes(tgt_code.co_code))
             # assert nice_gen == nice_tgt, nice_gen + "\n-----------------\n" + nice_tgt
+            assert prune_and_compare(gen_code, tgt_code), (
+                nice_gen + "\n-----------------\n" + nice_tgt
+            )
 
     return test


### PR DESCRIPTION
- Added partial Python 3.12 decompilation support (new opcode/jump encodings such as `RETURN_CONST`, `COMPARE_OP`, `POP_JUMP_*`, `FOR_ITER`, and `END_FOR` handling).
- Improved reconstruction for conditional expressions to account for specific control-flow artifacts in generated source.
- Added recovery of inline Python 3.12 comprehensions (filters and nested) back to `list`/`set`/`dict` comprehensions.